### PR TITLE
Updates Gradle repositories removing jcenter which is deprecated

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
The library is getting its dependencies from the jcenter repository which is deprecated.
 Need to change it to mavenCentral to fix issues when building this with Gradle.