### PR TITLE
fix: build error on flutter 3.24.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.example.launchexternalapp'
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Fix the following error that occurs when compiling for an Android build on Flutter 3.24.0

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':external_app_launcher:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR: /Users/takayama/ghq/github.com/medpeer-dev/navel/build/external_app_launcher/intermediates/merged_res/release/values/values.xml:194: AAPT: error: resource android:attr/
lStar not found.
```