### PR TITLE
feat(android): intent URI support (closes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,126 +1,219 @@
 ## Overview
 
-A Flutter plugin which helps you to open another app from your app. The package asks you for four parameters out of which two are mandatory.
+A Flutter plugin to open another app from your app, with optional store redirect when the target app is not installed.
 
-## Getting Started
+## Installation
 
-## 1. Add package to your project
+Add the package via [pub.dev](https://pub.dev/packages/external_app_launcher/install).
 
-Complete description to add this package to your project can be found [here](https://pub.dev/packages/external_app_launcher/install).
+---
 
-## 2. To setup native performance for the application in order to launch external apps
+## Platform setup
 
-## For opening apps in android
+### Android
 
-For opening an external app from your app in android, you need provide packageName of the app.
+Add a `<queries>` block **above the `<application>` tag** in `android/app/src/main/AndroidManifest.xml` for each package you intend to check or launch. This is required on Android 11+ — without it the system hides other packages and every call will behave as if the app is not installed.
 
-If the plugin finds the app in the device, it will be be launched. But if the the app is not installed in the device then it leads the user to playstore link of the app.
+```xml
+<queries>
+    <package android:name="com.target.app" />
+</queries>
+```
 
-> But if you don't want to redirect to playstore after installation then add the below script to `AndroidManifest.xml` file.
-     
-     <queries>
-       <package android:name="net.pulsesecure.pulsesecure" /> // your android package name
-     </queries>
-    
-    // Above <application> tag
-    
-    // Inside <intent-filter> add below existing <action> or <category>
-    <category android:name="android.intent.category.HOME"/> 
-    <category android:name="android.intent.category.DEFAULT"/>
+If you use `androidIntentUri`, also declare the intent scheme your URI uses:
+
+```xml
+<queries>
+    <package android:name="com.target.app" />
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <data android:scheme="https" />
+    </intent>
+</queries>
+```
+
+### iOS
+
+Add the URL scheme of each app you want to query under `LSApplicationQueriesSchemes` in `ios/Runner/Info.plist`:
+
+```xml
+<key>LSApplicationQueriesSchemes</key>
+<array>
+    <string>pulsesecure</string>
+</array>
+```
+
+Only the **scheme** needs to be listed (e.g. `pulsesecure`), not the full URL. `iosUrlScheme` may include a path and query string for deep links (e.g. `myapp://path?code=123`).
+
+---
+
+## Usage
+
+### `LaunchApp.openApp`
+
+Opens the target app. If the app is not installed, redirects to the Play Store / App Store when `openStore` is not `false`.
+
+| Parameter | Platform | Description |
+|-----------|----------|-------------|
+| `androidPackageName` | Android | Application id (e.g. `com.instagram.android`) |
+| `iosUrlScheme` | iOS | URL scheme or full deep-link URL (e.g. `instagram://`) |
+| `appStoreLink` | Both | Store URL to open when the app is missing |
+| `openStore` | Both | Set `false` to suppress the store redirect |
+| `androidIntentUri` | Android | Full [intent-scheme URI](https://developer.android.com/reference/android/content/Intent#intent-scheme) for passing data to the target app |
+
+Returns `1` when the app was opened, `0` otherwise.
+
+**Basic usage:**
+
+```dart
+await LaunchApp.openApp(
+  androidPackageName: 'net.pulsesecure.pulsesecure',
+  iosUrlScheme: 'pulsesecure://',
+  appStoreLink: 'itms-apps://itunes.apple.com/us/app/pulse-secure/id945832041',
+  // openStore: false
+);
+```
+
+**With intent URI (Android) — for passing data to the target app:**
+
+```dart
+await LaunchApp.openApp(
+  androidIntentUri:
+      'intent://payment#Intent;scheme=twint;S.code=T23LU9K;S.startingOrigin=EXTERNAL_WEB_BROWSER;end',
+  androidPackageName: 'ch.twint.payment', // optional; used for Play Store fallback
+  iosUrlScheme: 'twint://',
+);
+```
+
+### `LaunchApp.isAppInstalled`
+
+Returns `true` if the app is installed (Android) or its URL scheme is registered (iOS).
+
+```dart
+await LaunchApp.isAppInstalled(
+  androidPackageName: 'net.pulsesecure.pulsesecure',
+  iosUrlScheme: 'pulsesecure://',
+);
+```
+
+On Android, you can also pass `androidIntentUri` to check whether any activity on the device resolves that intent:
+
+```dart
+await LaunchApp.isAppInstalled(
+  androidIntentUri: 'intent://payment#Intent;scheme=twint;S.code=abc;end',
+);
+```
+
+> **Note:** on iOS, `isAppInstalled` uses `canOpenURL` — it checks whether the scheme is registered, not whether a specific application is installed.
+
+---
 
 ## Demo
+
+**Android**
 
 <img src="https://user-images.githubusercontent.com/60135944/171337872-81b89d2c-2c8b-4ecf-9702-33788821124c.gif" width="400"/>
 
-## For opening apps in ios
-
-In iOS, for opening an external app from your app, you need to provide URLscheme of the target app.
-
-To know more about URLScheme refer to this [Link](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app)
-
-If your deployment target is greater than or equal to 9, then you also need to update external app information in `Info.plist`.
-
-    <key>LSApplicationQueriesSchemes</key>
-    <array>
-      <string>pulsesecure</string> // url scheme name of the app
-    </array>
-
-But unlike in Android, it will not navigate to store (appStore) if app is not found in the device.
-
-For doing so you need to provide the iTunes link of the app.
-## Demo
+**iOS**
 
 <img src="https://user-images.githubusercontent.com/60135944/171337798-bdf3f78d-d002-4353-aab3-8b07dd688916.gif" width="400"/>
 
-## Implementation
+---
 
-Apart from opening an external app, this package can also be used to check whether an app is installed in the device or not.
+## Full example
 
-This can done by simply calling the function `isAppInstalled`
+```dart
+import 'package:flutter/material.dart';
+import 'package:external_app_launcher/external_app_launcher.dart';
 
-    await LaunchApp.isAppInstalled(
-      androidPackageName: 'net.pulsesecure.pulsesecure'
-      iosUrlScheme: 'pulsesecure://'
-    );
+void main() {
+  runApp(const MyApp());
+}
 
-This returns true and false based on the fact whether app is installed or not.
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
 
-## Code Illustration
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Plugin example app')),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
 
-    import 'package:flutter/material.dart';
-    import 'package:external_app_launcher/external_app_launcher.dart';
-
-    void main() {
-      runApp(MyApp());
-    }
-
-    class MyApp extends StatefulWidget {
-      @override
-      _MyAppState createState() => _MyAppState();
-    }
-
-    class _MyAppState extends State<MyApp> {
-      @override
-      void initState() {
-        super.initState();
-      }
-
-      Color containerColor = Colors.red;
-
-      @override
-      Widget build(BuildContext context) {
-        return MaterialApp(
-          home: Scaffold(
-            appBar: AppBar(
-              title: const Text('Plugin example app'),
-            ),
-            body: Center(
-              child: Container(
-                height: 50,
-                width: 150,
-                child: RaisedButton(
-                  color: Colors.blue,
-                  onPressed: () async {
-                    await LaunchApp.openApp(
-                      androidPackageName: 'net.pulsesecure.pulsesecure',
-                      iosUrlScheme: 'pulsesecure://',
-                      appStoreLink: 'itms-apps://itunes.apple.com/us/app/pulse-secure/id945832041',
-                      // openStore: false
-                    );
-
-                    // Enter the package name of the App you want to open and for iOS add the URLscheme to the Info.plist file.
-                    // The `openStore` argument decides whether the app redirects to PlayStore or AppStore.
-                    // For testing purpose you can enter com.instagram.android
-                  },
-                  child: Container(
-                    child: Center(
-                      child: Text("Open",
-                        textAlign: TextAlign.center,
-                      ),
-                    ))),
+              // 1. Basic launch — opens Instagram if installed, otherwise redirects
+              //    to the store. Returns 1 when the app opened, 0 otherwise.
+              //    Add the package to <queries> in AndroidManifest.xml (Android 11+).
+              ElevatedButton(
+                onPressed: () async {
+                  final result = await LaunchApp.openApp(
+                    androidPackageName: 'com.instagram.android',
+                    iosUrlScheme: 'instagram://',
+                    // When the app is not installed:
+                    //   Android → Play Store (pass openStore: false to suppress)
+                    //   iOS     → App Store via appStoreLink (no redirect without it)
+                    appStoreLink:
+                        'itms-apps://itunes.apple.com/app/instagram/id389801252',
+                    // openStore: false  // uncomment to disable store redirect
+                  );
+                  debugPrint('openApp result: $result');
+                },
+                child: const Text('Open Instagram'),
               ),
-            ),
+
+              // 2. Check install state before deciding whether to prompt the user.
+              //    On iOS this follows canOpenURL rules — it checks if the scheme
+              //    is registered, not whether the exact app is installed.
+              ElevatedButton(
+                onPressed: () async {
+                  final installed = await LaunchApp.isAppInstalled(
+                    androidPackageName: 'com.instagram.android',
+                    iosUrlScheme: 'instagram://',
+                  );
+                  debugPrint('Instagram installed: $installed');
+                },
+                child: const Text('Is Instagram installed?'),
+              ),
+
+              // 3. Android intent URI — use this when you need to pass data to the
+              //    target app (action, extras, etc.) rather than just opening it.
+              //    The intent string is parsed via Intent.parseUri on the native side.
+              //    androidPackageName is optional here; it is only used as a fallback
+              //    for the Play Store link when the intent cannot be resolved.
+              //    Declare the intent scheme under <queries> in AndroidManifest.xml.
+              //
+              //    This example opens the Gmail compose screen pre-filled with a
+              //    recipient — the S.* extras are string key/value pairs passed to
+              //    the target activity.
+              ElevatedButton(
+                onPressed: () async {
+                  // Check first whether any activity resolves the intent.
+                  final resolvable = await LaunchApp.isAppInstalled(
+                    androidIntentUri:
+                        'intent:#Intent;action=android.intent.action.SENDTO;scheme=mailto;package=com.google.android.gm;S.android.intent.extra.EMAIL=support%40example.com;S.android.intent.extra.SUBJECT=Hello;end',
+                  );
+                  debugPrint('Gmail compose resolvable: $resolvable');
+
+                  if (resolvable) {
+                    final result = await LaunchApp.openApp(
+                      androidIntentUri:
+                          'intent:#Intent;action=android.intent.action.SENDTO;scheme=mailto;package=com.google.android.gm;S.android.intent.extra.EMAIL=support%40example.com;S.android.intent.extra.SUBJECT=Hello;end',
+                      androidPackageName: 'com.google.android.gm', // Play Store fallback
+                      iosUrlScheme: 'googlegmail://',
+                    );
+                    debugPrint('openApp (intent URI) result: $result');
+                  }
+                },
+                child: const Text('Compose Gmail (intent URI)'),
+              ),
+
+            ],
           ),
-        );
-      }
-    }
+        ),
+      ),
+    );
+  }
+}
+```

--- a/android/src/main/java/com/example/launchexternalapp/LaunchexternalappPlugin.java
+++ b/android/src/main/java/com/example/launchexternalapp/LaunchexternalappPlugin.java
@@ -1,8 +1,10 @@
 package com.example.launchexternalapp;
 
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.text.TextUtils;
 import android.net.Uri;
 
@@ -106,7 +108,14 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
    */
   private boolean isAppInstalled(String packageName) {
     try {
-      context.getPackageManager().getPackageInfo(packageName, 0);
+      PackageManager pm = context.getPackageManager();
+      // PackageInfoFlags was introduced in API 33; the int overload is deprecated there
+      // but is the only option below it — both forms are equivalent for a flags value of 0.
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        pm.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0));
+      } else {
+        pm.getPackageInfo(packageName, 0);
+      }
       return true;
     } catch (PackageManager.NameNotFoundException ignored) {
       return false;
@@ -137,14 +146,25 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
       Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
       if (launchIntent != null) {
         launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        context.startActivity(launchIntent);
+        try {
+          context.startActivity(launchIntent);
+        } catch (ActivityNotFoundException e) {
+          // isAppInstalled passed, but the app could be uninstalled in the
+          // window between that check and here (TOCTOU). ActivityNotFoundException
+          // is unchecked, so without this catch it would silently crash the host app.
+          return "something went wrong";
+        }
         return "app_opened";
       }
-    } else if (!"false".equals(openStore)) { // Fixed incorrect string comparison
+    } else if (!"false".equals(openStore)) {
       Intent intent1 = new Intent(Intent.ACTION_VIEW);
       intent1.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       intent1.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
-      context.startActivity(intent1);
+      try {
+        context.startActivity(intent1);
+      } catch (ActivityNotFoundException e) {
+        return "something went wrong";
+      }
       return "navigated_to_store";
     }
     return "something went wrong";
@@ -166,21 +186,34 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
       Intent intent = Intent.parseUri(intentUriString, Intent.URI_INTENT_SCHEME);
       intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       if (intent.resolveActivity(context.getPackageManager()) != null) {
-        context.startActivity(intent);
+        try {
+          context.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+          // Guard against the app being uninstalled between resolveActivity and here.
+          return "something went wrong";
+        }
         return "app_opened";
       }
       if (!"false".equals(openStore)) {
         if (appStoreLink != null && !appStoreLink.isEmpty()) {
           Intent view = new Intent(Intent.ACTION_VIEW, Uri.parse(appStoreLink));
           view.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-          context.startActivity(view);
+          try {
+            context.startActivity(view);
+          } catch (ActivityNotFoundException e) {
+            return "something went wrong";
+          }
           return "navigated_to_store";
         }
         if (packageName != null && !packageName.isEmpty()) {
           Intent play = new Intent(Intent.ACTION_VIEW);
           play.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
           play.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
-          context.startActivity(play);
+          try {
+            context.startActivity(play);
+          } catch (ActivityNotFoundException e) {
+            return "something went wrong";
+          }
           return "navigated_to_store";
         }
       }

--- a/android/src/main/java/com/example/launchexternalapp/LaunchexternalappPlugin.java
+++ b/android/src/main/java/com/example/launchexternalapp/LaunchexternalappPlugin.java
@@ -8,13 +8,27 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
+import java.net.URISyntaxException;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-/** LaunchexternalappPlugin */
+/**
+ * Flutter plugin entry point for opening other apps on Android.
+ *
+ * <p>Communicates over the {@code launch_vpn} method channel. Dart passes either a
+ * plain package name (legacy path) or an {@code android_intent_uri} string for a
+ * full <a href="https://developer.android.com/reference/android/content/Intent#intent-scheme">intent
+ * URI</a> ({@code intent://…#Intent;…;end}). Intent URIs embed action, categories,
+ * and string extras ({@code S.*}) so callers can deep-link with data without
+ * building an {@link Intent} in Dart.
+ *
+ * <p>Return values are string tokens consumed by Dart and mapped to success (1)
+ * or failure (0); keep them stable for API compatibility.
+ */
 public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler {
 
   private MethodChannel channel;
@@ -47,17 +61,30 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
         result.success("Android " + android.os.Build.VERSION.RELEASE);
         break;
       case "isAppInstalled":
-        String packageName = call.argument("package_name");
-        if (packageName == null || TextUtils.isEmpty(packageName)) {
-          result.error("ERROR", "Empty or null package name", null);
+        // Dart: either android_intent_uri (resolveActivity) or package_name (getPackageInfo); not both.
+        String intentUri = call.argument("android_intent_uri");
+        if (intentUri != null && !TextUtils.isEmpty(intentUri)) {
+          result.success(isIntentResolvable(intentUri));
         } else {
-          result.success(isAppInstalled(packageName));
+          String packageName = call.argument("package_name");
+          if (packageName == null || TextUtils.isEmpty(packageName)) {
+            result.error("ERROR", "Empty or null package name", null);
+          } else {
+            result.success(isAppInstalled(packageName));
+          }
         }
         break;
       case "openApp":
-        packageName = call.argument("package_name");
         String openStore = call.argument("open_store");
-        result.success(openApp(packageName, openStore));
+        String appStoreLink = call.argument("app_store_link");
+        String androidIntentUri = call.argument("android_intent_uri");
+        if (androidIntentUri != null && !TextUtils.isEmpty(androidIntentUri)) {
+          String packageName = call.argument("package_name");
+          result.success(openAppWithIntentUri(androidIntentUri, openStore, appStoreLink, packageName));
+        } else {
+          String packageName = call.argument("package_name");
+          result.success(openApp(packageName, openStore));
+        }
         break;
       default:
         result.notImplemented();
@@ -65,6 +92,18 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
     }
   }
 
+  /**
+   * True when {@link PackageManager#getPackageInfo(String, int)} succeeds for this
+   * user/profile (i.e. the package is installed or otherwise visible to this app).
+   * False when no application id matches (uninstalled, typo, or different user).
+   * This does not guarantee a launchable activity exists.
+   *
+   * <p>{@code NameNotFoundException} is the API contract for "no such package";
+   * the catch variable is named {@code ignored} because we do not inspect it and
+   * only map failure to {@code false}.
+   *
+   * @param packageName application id (e.g. {@code com.example.app})
+   */
   private boolean isAppInstalled(String packageName) {
     try {
       context.getPackageManager().getPackageInfo(packageName, 0);
@@ -74,6 +113,25 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
     }
   }
 
+  /**
+   * Whether some activity on the device can handle the intent produced from an
+   * intent-scheme URI. Malformed URIs yield {@code false} (same as unresolvable).
+   */
+  private boolean isIntentResolvable(String intentUriString) {
+    try {
+      Intent intent = Intent.parseUri(intentUriString, Intent.URI_INTENT_SCHEME);
+      return intent.resolveActivity(context.getPackageManager()) != null;
+    } catch (URISyntaxException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Opens the default launcher activity for {@code packageName}, or the Play
+   * Store listing if the package is missing and store navigation is allowed.
+   *
+   * @return {@code app_opened}, {@code navigated_to_store}, or {@code something went wrong}
+   */
   private String openApp(String packageName, String openStore) {
     if (isAppInstalled(packageName)) {
       Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
@@ -90,5 +148,45 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
       return "navigated_to_store";
     }
     return "something went wrong";
+  }
+
+  /**
+   * Parses an intent URI, starts the resolved activity when possible, otherwise
+   * falls back in order: optional {@code appStoreLink} (VIEW), optional
+   * {@code packageName} Play listing, or an error string. Used when Dart passes
+   * {@code android_intent_uri}.
+   *
+   * @param packageName optional; used only for Play Store fallback when the intent
+   *                    does not resolve (e.g. same app id as the target market listing).
+   * @return {@code app_opened}, {@code navigated_to_store}, {@code App not found on the device},
+   *         or {@code invalid_intent_uri} if parsing fails
+   */
+  private String openAppWithIntentUri(String intentUriString, String openStore, String appStoreLink, String packageName) {
+    try {
+      Intent intent = Intent.parseUri(intentUriString, Intent.URI_INTENT_SCHEME);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      if (intent.resolveActivity(context.getPackageManager()) != null) {
+        context.startActivity(intent);
+        return "app_opened";
+      }
+      if (!"false".equals(openStore)) {
+        if (appStoreLink != null && !appStoreLink.isEmpty()) {
+          Intent view = new Intent(Intent.ACTION_VIEW, Uri.parse(appStoreLink));
+          view.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          context.startActivity(view);
+          return "navigated_to_store";
+        }
+        if (packageName != null && !packageName.isEmpty()) {
+          Intent play = new Intent(Intent.ACTION_VIEW);
+          play.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          play.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
+          context.startActivity(play);
+          return "navigated_to_store";
+        }
+      }
+      return "App not found on the device";
+    } catch (URISyntaxException e) {
+      return "invalid_intent_uri";
+    }
   }
 }

--- a/android/src/main/java/com/example/launchexternalapp/LaunchexternalappPlugin.java
+++ b/android/src/main/java/com/example/launchexternalapp/LaunchexternalappPlugin.java
@@ -148,7 +148,7 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
         launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         try {
           context.startActivity(launchIntent);
-        } catch (ActivityNotFoundException e) {
+        } catch (ActivityNotFoundException | SecurityException e) {
           // isAppInstalled passed, but the app could be uninstalled in the
           // window between that check and here (TOCTOU). ActivityNotFoundException
           // is unchecked, so without this catch it would silently crash the host app.
@@ -162,7 +162,7 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
       intent1.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
       try {
         context.startActivity(intent1);
-      } catch (ActivityNotFoundException e) {
+      } catch (ActivityNotFoundException | SecurityException e) {
         return "something went wrong";
       }
       return "navigated_to_store";
@@ -188,7 +188,7 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
       if (intent.resolveActivity(context.getPackageManager()) != null) {
         try {
           context.startActivity(intent);
-        } catch (ActivityNotFoundException e) {
+        } catch (ActivityNotFoundException | SecurityException e) {
           // Guard against the app being uninstalled between resolveActivity and here.
           return "something went wrong";
         }
@@ -200,7 +200,7 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
           view.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
           try {
             context.startActivity(view);
-          } catch (ActivityNotFoundException e) {
+          } catch (ActivityNotFoundException | SecurityException e) {
             return "something went wrong";
           }
           return "navigated_to_store";
@@ -211,7 +211,7 @@ public class LaunchexternalappPlugin implements FlutterPlugin, MethodCallHandler
           play.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + packageName));
           try {
             context.startActivity(play);
-          } catch (ActivityNotFoundException e) {
+          } catch (ActivityNotFoundException | SecurityException e) {
             return "something went wrong";
           }
           return "navigated_to_store";

--- a/ios/external_app_launcher/Sources/external_app_launcher/LaunchexternalappPlugin.m
+++ b/ios/external_app_launcher/Sources/external_app_launcher/LaunchexternalappPlugin.m
@@ -23,6 +23,7 @@
     
   } else if ([@"openApp" isEqualToString:call.method]) {
     @try {
+        // package_name is a full URL string; it may include ?query for deep-link data.
         NSURL *url = [NSURL URLWithString:call.arguments[@"package_name"]];
         if ([[UIApplication sharedApplication] canOpenURL:url]) {
             [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {

--- a/lib/external_app_launcher.dart
+++ b/lib/external_app_launcher.dart
@@ -13,41 +13,92 @@ class LaunchApp {
     return version;
   }
 
-  /// Function to check if app is installed on device
-  /// returns boolean
-  static isAppInstalled(
-      {String? iosUrlScheme, String? androidPackageName}) async {
-    String packageName = Platform.isIOS ? iosUrlScheme! : androidPackageName!;
-    if (packageName.isEmpty) {
-      throw Exception('The package name can not be empty');
+  /// Returns whether the target can be opened or resolved.
+  ///
+  /// **Android:** pass [androidPackageName], or [androidIntentUri] for an
+  /// `intent://…#Intent;…;end` string (resolved with Android `Intent.parseUri`).
+  ///
+  /// **iOS:** pass [iosUrlScheme] as a custom scheme URL. It may include a path
+  /// and query (e.g. `myapp://pay?code=…`) for deep links; declare the **scheme**
+  /// under `LSApplicationQueriesSchemes` in Info.plist.
+  static Future<dynamic> isAppInstalled({
+    String? iosUrlScheme,
+    String? androidPackageName,
+    String? androidIntentUri,
+  }) async {
+    if (Platform.isAndroid) {
+      final hasIntent = androidIntentUri != null && androidIntentUri.isNotEmpty;
+      final hasPkg =
+          androidPackageName != null && androidPackageName.isNotEmpty;
+      if (!hasIntent && !hasPkg) {
+        throw Exception(
+            'Either androidPackageName or androidIntentUri is required');
+      }
+      if (hasIntent) {
+        return _channel.invokeMethod('isAppInstalled', {
+          'android_intent_uri': androidIntentUri,
+        });
+      }
+    } else {
+      if (iosUrlScheme == null || iosUrlScheme.isEmpty) {
+        throw Exception('The iosUrlScheme can not be empty');
+      }
     }
-    dynamic isAppInstalled = await _channel
-        .invokeMethod('isAppInstalled', {'package_name': packageName});
-    return isAppInstalled;
+    final String packageName =
+        Platform.isIOS ? iosUrlScheme! : androidPackageName!;
+    return _channel.invokeMethod('isAppInstalled', {
+      'package_name': packageName,
+    });
   }
 
-  /// Function to launch the external app
-  /// or redirect to store
-  static Future<int> openApp(
-      {String? iosUrlScheme,
-      String? androidPackageName,
-      String? appStoreLink,
-      bool? openStore}) async {
-    String? packageName = Platform.isIOS ? iosUrlScheme : androidPackageName;
-    String packageVariableName =
-        Platform.isIOS ? 'iosUrlScheme' : 'androidPackageName';
-    if (packageName == null || packageName == "") {
-      throw Exception('The $packageVariableName can not be empty');
+  /// Launches another app, or may redirect to a store when the app is missing.
+  ///
+  /// **Android:** provide [androidPackageName] for a normal launch, **or**
+  /// [androidIntentUri] for a full intent URI (extras embedded in the URI per
+  /// Android’s intent scheme). You can pass both: the intent is tried first;
+  /// [androidPackageName] may be used for Play Store fallback.
+  ///
+  /// **iOS:** [iosUrlScheme] is sent to the system as a URL string; include query
+  /// parameters for deep-link data when the target app supports them.
+  static Future<int> openApp({
+    String? iosUrlScheme,
+    String? androidPackageName,
+    String? androidIntentUri,
+    String? appStoreLink,
+    bool? openStore,
+  }) async {
+    if (Platform.isAndroid) {
+      final hasIntent = androidIntentUri != null && androidIntentUri.isNotEmpty;
+      final hasPkg =
+          androidPackageName != null && androidPackageName.isNotEmpty;
+      if (!hasIntent && !hasPkg) {
+        throw Exception(
+            'Either androidPackageName or androidIntentUri is required');
+      }
+    } else {
+      if (iosUrlScheme == null || iosUrlScheme.isEmpty) {
+        throw Exception('The iosUrlScheme can not be empty');
+      }
     }
     if (Platform.isIOS && appStoreLink == null && openStore != false) {
       openStore = false;
     }
 
-    return await _channel.invokeMethod('openApp', {
-      'package_name': packageName,
+    final Map<String, dynamic> args = {
       'open_store': openStore == false ? "false" : "open it",
-      'app_store_link': appStoreLink
-    }).then((value) {
+      'app_store_link': appStoreLink,
+    };
+    if (Platform.isAndroid &&
+        androidIntentUri != null &&
+        androidIntentUri.isNotEmpty) {
+      args['android_intent_uri'] = androidIntentUri;
+      args['package_name'] = androidPackageName ?? '';
+    } else {
+      args['package_name'] =
+          Platform.isIOS ? iosUrlScheme! : androidPackageName!;
+    }
+
+    return await _channel.invokeMethod('openApp', args).then((value) {
       if (value == "app_opened") {
         print("app opened successfully");
         return 1;
@@ -67,5 +118,4 @@ class LaunchApp {
       }
     });
   }
-  // }
 }

--- a/lib/external_app_launcher.dart
+++ b/lib/external_app_launcher.dart
@@ -98,7 +98,8 @@ class LaunchApp {
           Platform.isIOS ? iosUrlScheme! : androidPackageName!;
     }
 
-    return await _channel.invokeMethod('openApp', args).then((value) {
+    try {
+      final value = await _channel.invokeMethod('openApp', args);
       if (value == "app_opened") {
         print("app opened successfully");
         return 1;
@@ -116,6 +117,14 @@ class LaunchApp {
         }
         return 0;
       }
-    });
+    } on PlatformException catch (e) {
+      // Thrown by the Flutter framework when the native side calls result.error().
+      print("Failed to open app: ${e.message}");
+      return 0;
+    } catch (e) {
+      // Catches MissingPluginException (plugin not registered) and anything else unexpected.
+      print("Failed to open app: $e");
+      return 0;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds optional `androidIntentUri` for Android [intent-scheme URIs](https://developer.android.com/reference/android/content/Intent#intent-scheme) (`Intent.parseUri`), updates `isAppInstalled` for intent resolution, documents Android 11+ `<queries>`, and refreshes the README with platform setup, parameter table, and examples.

Closes https://github.com/GeekyAnts/external_app_launcher/issues/28

Tested on android real device and ios simulator